### PR TITLE
Overhauled requirement check script, and simplified boolean return in ShouldAvoidItem

### DIFF
--- a/root/scripts/vscripts/director_base_addon.nut
+++ b/root/scripts/vscripts/director_base_addon.nut
@@ -5,18 +5,10 @@
 		foreach (item in Left4Bots.ItemsToAvoid)
 		{
 			if (classname.find(item) != null)
-			{
-				if (Left4Bots.Settings.items_not_to_avoid)
-					return false;
-				else
-					return true;
-			}
+				return !Left4Bots.Settings.items_not_to_avoid;
 		}
 		
-		if (Left4Bots.Settings.items_not_to_avoid)
-			return true;
-		else
-			return false;
+		return Left4Bots.Settings.items_not_to_avoid;
 	}
 }
 

--- a/root/scripts/vscripts/left4bots_requirements.nut
+++ b/root/scripts/vscripts/left4bots_requirements.nut
@@ -5,56 +5,30 @@
 
 if (!("L4ReqChecker" in getroottable()))
 {
-	::L4ReqChecker <-
-	{
-		DummyEnt = null
-		Count = 0
-	}
-
-	::L4ReqChecker.ThinkFunc <- function()
+	::L4ReqChecker <- {};
+	
+	L4ReqChecker.CheckRequirement <- function (checkcount)
 	{
 		if (!("Left4Utils" in ::getroottable()))
 		{
-			if (L4ReqChecker.Count++ >= 10)
+			if (checkcount++ >= 10)
 			{
-				L4ReqChecker.DummyEnt.Kill();
-				delete ::L4ReqChecker;
-				
-				printl("[L4ReqChecker][DEBUG] Dummy entity killed");
+				printl("[L4ReqChecker][DEBUG] Requirement check failed!");
+				return;
 			}
-			else
-			{
-				ClientPrint(null, 3, "\x04WARNING:\x01 Required addon \x03 Left 4 Lib\x01 is missing!");
-				ClientPrint(null, 3, "\x03Left 4 Bots\x01,\x03 Left 4 Grief\x01 and\x03 Left 4 Fun\x01 addons require the\x03 Left 4 Lib\x01 addon to be installed and enabled in order to work properly.");
-				ClientPrint(null, 3, "\x01Please, check the\x03 REQUIRED ITEMS\x01 section on the addons workshop pages.");
-			}
+			
+			ClientPrint(null, 3, "\x04WARNING:\x01 Required addon \x03 Left 4 Lib\x01 is missing!");
+			ClientPrint(null, 3, "\x03Left 4 Bots\x01,\x03 Left 4 Grief\x01 and\x03 Left 4 Fun\x01 addons require the\x03 Left 4 Lib\x01 addon to be installed and enabled in order to work properly.");
+			ClientPrint(null, 3, "\x01Please, check the\x03 REQUIRED ITEMS\x01 section on the addons workshop pages.");
 		}
-		else if (L4ReqChecker.Count++ >= 2)
+		else if (checkcount++ >= 2)
 		{
-			L4ReqChecker.DummyEnt.Kill();
-			delete ::L4ReqChecker;
-			
-			printl("[L4ReqChecker][DEBUG] Dummy entity killed");
+			printl("[L4ReqChecker][DEBUG] Requirement checked successfully!");
+			return;
 		}
-		
-		return 10.0;
+		DoEntFire("worldspawn", "RunScriptCode", "g_ModeScript.L4ReqChecker.CheckRequirement(" + checkcount + ")", 10.0, null, null);
 	}
+	
+	// Recursive function, GO!
+	DoEntFire("worldspawn", "RunScriptCode", "g_ModeScript.L4ReqChecker.CheckRequirement(" + 0 + ")", 0.0, null, null);
 }
-
-if (!::L4ReqChecker.DummyEnt || !::L4ReqChecker.DummyEnt.IsValid())
-{
-	::L4ReqChecker.DummyEnt = SpawnEntityFromTable("info_target", { targetname = "l4reqchecker" });
-	if (::L4ReqChecker.DummyEnt)
-	{
-		::L4ReqChecker.DummyEnt.ValidateScriptScope();
-		local scope = ::L4ReqChecker.DummyEnt.GetScriptScope();
-		scope["L4ReqCheckerThinkFunc"] <- ::L4ReqChecker.ThinkFunc;
-		AddThinkToEnt(::L4ReqChecker.DummyEnt, "L4ReqCheckerThinkFunc");
-			
-		printl("[L4ReqChecker][DEBUG] Spawned dummy entity");
-	}
-	else
-		error("[L4ReqChecker][ERROR] Failed to spawn dummy entity!\n");
-}
-else
-	printl("[L4ReqChecker][DEBUG] Dummy entity already spawned");


### PR DESCRIPTION
### First change
I removed two "if" and "else" branches from the _DirectorScript.GetDirectorOptions().ShouldAvoidItem_ function (and skipped straight to returning the bool it's checking for since I didn't see much else overtly going on there.)
Unless there are plans for other checks in it, I can safely say that's a few instructions saved at least.

### Second change
Additionally, I overhauled the requirement check script to use _DoEntFire_ on the _worldspawn_ entity to fire a recursive function, which is a repurpose of its dummy entity's think function, that allows it to replicate a roughly temporary looping timer.
Henceforth, I removed that script's need for a temporary debug entity and thinker (and the data necessary for it) to perform these checks. (Its debug logging messages have been altered to reflect this.)

### Last notes
I made certain to test (and alter as appropriate) before putting them up.

I'm starting off small, so I chose to change these ones specifically at first (at least because then they'd be the easier changes to review, debug and test.)