### PR TITLE
Tiny optimization for a debug log early on in the OnGameEvent_round_start hook.

### DIFF
--- a/root/scripts/vscripts/left4bots_events.nut
+++ b/root/scripts/vscripts/left4bots_events.nut
@@ -14,13 +14,8 @@ Msg("Including left4bots_events...\n");
 	if (!("AllowWitchesInCheckpoints" in DirectorScript.GetDirectorOptions()))
 		DirectorScript.GetDirectorOptions().AllowWitchesInCheckpoints <- false;
 	
-	if ("Left4Fun" in getroottable() && "PingEnt" in ::Left4Fun)
-	{
-		Left4Bots.L4F = true;
-		Left4Bots.Log(LOG_LEVEL_DEBUG, "L4F = true");
-	}
-	else
-		Left4Bots.Log(LOG_LEVEL_DEBUG, "L4F = false");
+	Left4Bots.L4F = ("Left4Fun" in getroottable() && "PingEnt" in ::Left4Fun);
+	Left4Bots.Log(LOG_LEVEL_DEBUG, "L4F = " + Left4Bots.L4F.tostring());
 
 	// Start receiving concepts
 	::ConceptsHub.SetHandler("Left4Bots", Left4Bots.OnConcept);


### PR DESCRIPTION
Because a debug log bit for Left 4 Fun in the early part of the _OnGameEvent_round_start_ hook was surprisingly easy to simplify, I was able to remove an "if" and "else" condition, and applied the condition it checked for directly onto _Left4Bots.L4F_, and using a (temporary) string version of the bool itself in the log.

(Unless said message as a whole will be changed or smthing. In which case, this pull can be safely ignored.)

With that said, this might take a tad longer to review than my earlier pull request, if only because now it needs to be quickly tested with **Left 4 Fun** active. But I'm confident this won't take long, and that it won't produce a bug or two (at least, that's the hope.)