### PR TITLE
Attempted optimization on Left4Bots.InventoryManager, and *slightly* lowered tick interval of "L4BThinker" to 0.0666.

### DIFF
--- a/root/scripts/vscripts/left4bots_events.nut
+++ b/root/scripts/vscripts/left4bots_events.nut
@@ -32,7 +32,7 @@ Msg("Including left4bots_events...\n");
 	Left4Timers.AddTimer("InventoryManager", 0.5, Left4Bots.OnInventoryManager, {}, true);
 	
 	// Start the thinker
-	Left4Timers.AddThinker("L4BThinker", 0.01, Left4Bots.OnThinker, {});
+	Left4Timers.AddThinker("L4BThinker", 0.0666, Left4Bots.OnThinker, {});
 	
 	DirectorScript.GetDirectorOptions().cm_ShouldHurry <- Left4Bots.Settings.should_hurry;
 }
@@ -1441,42 +1441,32 @@ Msg("Including left4bots_events...\n");
 			local inv = {};
 			GetInvTable(surv, inv);
 			
-			if (INV_SLOT_PRIMARY in inv)
-			{
-				if (inv[INV_SLOT_PRIMARY].GetClassname().find("shotgun"))
-					Left4Bots.TeamShotguns++;
-			}
+			if (INV_SLOT_PRIMARY in inv) // Strings are a char array -- start at index 5, which is after "weapon", and the search should go by quicker.
+				Left4Bots.TeamShotguns += (inv[INV_SLOT_PRIMARY].GetClassname().find("shotgun", 5) != null).tointeger();
 			
 			if (INV_SLOT_SECONDARY in inv)
 			{
 				local cls = inv[INV_SLOT_SECONDARY].GetClassname();
 				
-				if (cls == "weapon_chainsaw")
-					Left4Bots.TeamChainsaws++;
-				else if (cls == "weapon_melee")
-					Left4Bots.TeamMelee++;
+				Left4Bots.TeamChainsaws += (cls == "weapon_chainsaw").tointeger();
+				Left4Bots.TeamMelee += (cls == "weapon_melee").tointeger();
 			}
 			
 			if (INV_SLOT_THROW in inv)
 			{
 				local cls = inv[INV_SLOT_THROW].GetClassname();
 				
-				if (cls == "weapon_molotov")
-					Left4Bots.TeamMolotovs++;
-				else if (cls == "weapon_pipe_bomb")
-					Left4Bots.TeamPipeBombs++;
-				else if (cls == "weapon_vomitjar")
-					Left4Bots.TeamVomitJars++;
+				Left4Bots.TeamMolotovs += (cls == "weapon_molotov").tointeger();
+				Left4Bots.TeamPipeBombs += (cls == "weapon_pipe_bomb").tointeger();
+				Left4Bots.TeamVomitJars += (cls == "weapon_vomitjar").tointeger();
 			}
 			
 			if (INV_SLOT_MEDKIT in inv)
 			{
 				local cls = inv[INV_SLOT_MEDKIT].GetClassname();
 				
-				if (cls == "weapon_first_aid_kit")
-					Left4Bots.TeamMedkits++;
-				else if (cls == "weapon_defibrillator")
-					Left4Bots.TeamDefibs++;
+				Left4Bots.TeamMedkits += (cls == "weapon_first_aid_kit").tointeger();
+				Left4Bots.TeamDefibs += (cls == "weapon_defibrillator").tointeger();
 			}
 		}
 	}

--- a/root/scripts/vscripts/left4bots_events.nut
+++ b/root/scripts/vscripts/left4bots_events.nut
@@ -32,7 +32,7 @@ Msg("Including left4bots_events...\n");
 	Left4Timers.AddTimer("InventoryManager", 0.5, Left4Bots.OnInventoryManager, {}, true);
 	
 	// Start the thinker
-	Left4Timers.AddThinker("L4BThinker", 0.0666, Left4Bots.OnThinker, {});
+	Left4Timers.AddThinker("L4BThinker", 0.0333, Left4Bots.OnThinker, {});
 	
 	DirectorScript.GetDirectorOptions().cm_ShouldHurry <- Left4Bots.Settings.should_hurry;
 }
@@ -1441,8 +1441,8 @@ Msg("Including left4bots_events...\n");
 			local inv = {};
 			GetInvTable(surv, inv);
 			
-			if (INV_SLOT_PRIMARY in inv) // Strings are a char array -- start at index 5, which is after "weapon", and the search should go by quicker.
-				Left4Bots.TeamShotguns += (inv[INV_SLOT_PRIMARY].GetClassname().find("shotgun", 5) != null).tointeger();
+			// Strings are a char array -- start the classname search at index 5, which is after "weapon", and the search should go by quicker.
+			Left4Bots.TeamShotguns += (INV_SLOT_PRIMARY in inv && inv[INV_SLOT_PRIMARY].GetClassname().find("shotgun", 5) != null).tointeger();
 			
 			if (INV_SLOT_SECONDARY in inv)
 			{


### PR DESCRIPTION
### First change
This change for _Left4Bots.InventoryManager_ is purely experimental -- for one thing, this means a significantly reduced amount of "if" and "else" conditions in the "foreach" loop dedicated to weighing up what items are needed. Less "if" branches in a for loop = less instructions for the CPU to keep track of while it's doing that "for" loop, and it goes vroom vroom.

Instead of incrementing after an "if" condition, it increments using an integer-casted bool version of these conditions. So if the bool is true, it's 1, and 0 otherwise. (Something I learned by complete accident while messing around in C++-styled stuff.)
A few immediately temporary, 'er, integer-casted bools will need to be used on the other hand -- but I don't think this could tax anything too roughly.

### Second change
The "L4BThinker" thinker's think interval is set to 0.0666, as entities that inherit from _CTerrorPlayer_ class (i.e. player entities in this game) are capped at a tick interval of 0.0666 seconds, or half as slow as the tick rate (an estimated 15, if I'm not mistaken from some quick math) of the game's own, 30 ticks per second.
I mainly thought slowing the thinker interval to that rate could help _slightly_ lighten the frequency if it's slowed to be equal with the player entities' halved tick rate.

Here is the [source](https://developer.valvesoftware.com/wiki/Entity_Scripts#Thinker_Functions) for how I learned of the tick rate stuff for entity-related scripting purposes in this game.
Here is another [source](https://developer.valvesoftware.com/wiki/Source_Multiplayer_Networking#Basic_networking) I checked purely so I could make absolutely certain this game's tickrate was indeed 30, and that it _couldn't_ be changed.

### Last notes
Sooner or later, I'll propose an optimization (because this one is what I'd call a "significant change") in the issues tab, revolving around how the check for Tank rocks can be hoisted out of the frequently-executing _Left4Bots.OnThinker_. This will come listed with steps on how this can be implemented, the benefits, and drawbacks worth evaluating (and a compromise as a backup plan,) hence it meriting discussion.

(Also, don't mind the # numbers referring to pull requests/issues or something in the update log for my pull. They were unintentional by way of my attempt to add flair to counting changes, not knowing it could do that instead. XvX")