### PR TITLE
Quickly updated Left4Bots.Log to use a switch statement.

### DIFF
--- a/root/scripts/vscripts/left4bots.nut
+++ b/root/scripts/vscripts/left4bots.nut
@@ -145,16 +145,24 @@ IncludeScript("left4bots_settings");
 	if (level > Left4Bots.Settings.loglevel)
 		return;
 	
-	if (level == LOG_LEVEL_DEBUG)
-		printl("[L4B][DEBUG] " + text);
-	else if (level == LOG_LEVEL_INFO)
-		printl("[L4B][INFO] " + text);
-	else if (level == LOG_LEVEL_WARN)
-		error("[L4B][WARNING] " + text + "\n");
-	else if (level == LOG_LEVEL_ERROR)
-		error("[L4B][ERROR] " + text + "\n");
-	else
-		error("[L4B][" + level + "] " + text + "\n");
+	switch (level)
+	{
+		case LOG_LEVEL_DEBUG:
+			printl("[L4B][DEBUG] " + text);
+			break;
+		case LOG_LEVEL_INFO:
+			printl("[L4B][INFO] " + text);
+			break;
+		case LOG_LEVEL_WARN:
+			error("[L4B][WARNING] " + text + "\n");
+			break;
+		case LOG_LEVEL_ERROR:
+			error("[L4B][ERROR] " + text + "\n");
+			break;
+		default:
+			error("[L4B][" + level + "] " + text + "\n");
+			break;
+	}
 }
 
 // Left4Bots main initialization function


### PR DESCRIPTION
Exactly what it says on the tin.

An "if-else" chain in _Left4Bots.Log_ has been replaced with a switch statement, as each "if" condition just checked one value, and a switch statement only needs to worry about checking one value across differing results anyway.
(_Unless_ the log function is going to have more complex "if" conditions, that is.)

This can be reused for the other L4Library mods' dedicated log functions as well.