### PR TITLE
Bugfix for follow, goto, and heal player commands

### DIFF
--- a/root/scripts/vscripts/left4bots.nut
+++ b/root/scripts/vscripts/left4bots.nut
@@ -555,10 +555,10 @@ IncludeScript("left4bots_settings");
 ::Left4Bots.GetBotByName <- function (name)
 {
 	local n = name.tolower();
-	foreach (bot in Bots)
+	foreach (surv in Survivors)
 	{
-		if (bot.IsValid() && bot.GetPlayerName().tolower() == n)
-			return bot;
+		if (surv.IsValid() && Left4Utils.GetCharacterName(surv).tolower() == n)
+			return surv;
 	}
 	return null;
 }


### PR DESCRIPTION
This fixes an issue where the follow, goto, and heal commands do not work when selecting a player as the target as opposed to another bot. Most prevalent when playing with multiple people.