### PR TITLE
Fixed automation and release minigun

### DIFF
--- a/root/scripts/vscripts/left4bots_ai.nut
+++ b/root/scripts/vscripts/left4bots_ai.nut
@@ -3459,10 +3459,14 @@ enum AI_AIM_TYPE {
 	CarryItemWeaponId = 0;
 	*/
 	
-	//lxc apply changes
+	// Aim stuff
 	BotUnSetAim();
 	OrderHuman = null;
 	OrderTarget = null;
+	
+	// Minigun
+	if (NetProps.GetPropInt(self, "m_usingMountedWeapon") > 0)
+		L4B.PlayerPressButton(self, BUTTON_USE);
 }
 
 // Check if the bot should pause what he is doing. Handles the Paused flag and the RESET command

--- a/root/scripts/vscripts/left4bots_events.nut
+++ b/root/scripts/vscripts/left4bots_events.nut
@@ -1147,6 +1147,13 @@ Msg("Including left4bots_events...\n");
 			SurvivorFlow[userid].isBot = true;
 
 			AddBotThink(player);
+			
+			// fixed new bot ignore exists custom automation task
+			foreach (task in Automation.CurrentTasks)
+			{
+				if (task._allBots && "_ordersSent" in task)
+					task._ordersSent = false;
+			}
 		}
 		else if (Settings.play_sounds)
 		{


### PR DESCRIPTION
Fixed new spawn bot ignore exists custom automation task. #118 
Fixed bot not release the minigun when player use cancel/move command.